### PR TITLE
Add conditions for link mapping

### DIFF
--- a/Classes/Port/Service/LinkMappingService.php
+++ b/Classes/Port/Service/LinkMappingService.php
@@ -122,7 +122,7 @@ class LinkMappingService
             foreach ($this->getPropertiesWithRelations()[$tableName] as $configuration) {
                 $field = $configuration['field'];
                 $table = $configuration['table'];
-                $conditions = $configuration['conditions'];
+                $conditions = $configuration['conditions'] ?? [];
                 if (array_key_exists($field, $properties)) {
                     if (!empty($conditions)) {
                         // Do not update value if conditions not met

--- a/Classes/Port/Service/LinkMappingService.php
+++ b/Classes/Port/Service/LinkMappingService.php
@@ -122,11 +122,11 @@ class LinkMappingService
             foreach ($this->getPropertiesWithRelations()[$tableName] as $configuration) {
                 $field = $configuration['field'];
                 $table = $configuration['table'];
-                $condition = $configuration['condition'];
+                $conditions = $configuration['conditions'];
                 if (array_key_exists($field, $properties)) {
-                    if (!empty($condition)) {
+                    if (!empty($conditions)) {
                         // Do not update value if conditions not met
-                        foreach ($condition as $conditionField => $conditionValue) {
+                        foreach ($conditions as $conditionField => $conditionValue) {
                             if (!array_key_exists($conditionField, $properties) || $properties[$conditionField] !== $conditionValue) {
                                 continue 2;
                             }

--- a/Classes/Port/Service/LinkMappingService.php
+++ b/Classes/Port/Service/LinkMappingService.php
@@ -122,7 +122,16 @@ class LinkMappingService
             foreach ($this->getPropertiesWithRelations()[$tableName] as $configuration) {
                 $field = $configuration['field'];
                 $table = $configuration['table'];
+                $condition = $configuration['condition'];
                 if (array_key_exists($field, $properties)) {
+                    if (!empty($condition)) {
+                        // Do not update value if conditions not met
+                        foreach ($condition as $conditionField => $conditionValue) {
+                            if (!array_key_exists($conditionField, $properties) || $properties[$conditionField] !== $conditionValue) {
+                                continue 2;
+                            }
+                        }
+                    }
                     $properties[$field] = $this->updateValueWithSimpleLinks((string)$properties[$field], $table);
                 }
             }

--- a/Documentation/Port.md
+++ b/Documentation/Port.md
@@ -167,7 +167,16 @@ return [
                     'field' => 'parent_category',
                     'table' => 'tt_news_cat'
                 ]
-            ]
+            ],
+            'tx_inline_relation' => [
+                [
+                    'field' => 'parent_record',
+                    'table' => 'tx_inline_origin',
+                    'conditions' => [
+                        'parent_table' => 'tx_inline_origin'
+                    ]
+                ]
+            ],
         ],
 
         /**


### PR DESCRIPTION
If there are records with inline relation and `parent_record` links to the UID and `parent_table` links to the table name, the importer does not link correctly.

With this PR incl. updated documentation it works with conditions on link mapping.