### PR TITLE
[BUGFIX] remove strict return type for replace property helper getValue

### DIFF
--- a/Classes/Migration/PropertyHelpers/ReplacePropertyHelper.php
+++ b/Classes/Migration/PropertyHelpers/ReplacePropertyHelper.php
@@ -58,9 +58,9 @@ class ReplacePropertyHelper extends AbstractPropertyHelper implements PropertyHe
     }
 
     /**
-     * @return string
+     * @return mixed
      */
-    protected function getValue(): string
+    protected function getValue()
     {
         $value = $this->getProperty();
         if ($this->getConfigurationByKey('startField') !== null) {


### PR DESCRIPTION
the strict return type string leads to an exception if the property or startField value is not a string (e.g. integer). 
Now the property value is passed with the current type.