### PR TITLE
Fix mm import duplicate key errors

### DIFF
--- a/Classes/Port/Import.php
+++ b/Classes/Port/Import.php
@@ -272,11 +272,14 @@ class Import
      */
     protected function importMmRecords(): void
     {
+        $excludedTables = array_merge(['sys_file_reference'], $this->configuration['excludedTables']);
         if (is_array($this->jsonArray['mm'])) {
             foreach ($this->jsonArray['mm'] as $tableMm => $records) {
-                if (DatabaseUtility::isTableExisting($tableMm)) {
-                    foreach ($records as $record) {
-                        $this->insertRecord($this->getNewPropertiesForMmRelation($record, $tableMm), $tableMm);
+                if (in_array($tableMm, $excludedTables) === false) {
+                    if (DatabaseUtility::isTableExisting($tableMm)) {
+                        foreach ($records as $record) {
+                            $this->insertRecord($this->getNewPropertiesForMmRelation($record, $tableMm), $tableMm);
+                        }
                     }
                 }
             }

--- a/Classes/Port/Import.php
+++ b/Classes/Port/Import.php
@@ -276,8 +276,7 @@ class Import
             foreach ($this->jsonArray['mm'] as $tableMm => $records) {
                 if (DatabaseUtility::isTableExisting($tableMm)) {
                     foreach ($records as $record) {
-                        $connection = DatabaseUtility::getConnectionForTable($tableMm);
-                        $connection->insert($tableMm, $this->getNewPropertiesForMmRelation($record, $tableMm));
+                        $this->insertRecord($this->getNewPropertiesForMmRelation($record, $tableMm), $tableMm);
                     }
                 }
             }


### PR DESCRIPTION
I had two problems when extending the relation config with my own tables:

1. I got duplicate key errors if the relation table already has entries with the same id,  because the ids were not rewritten but just inserted with $connection->insert.

2. If the relation was to sys_file_reference, the entry was added two times, one time in In2code\Migration\Port\Import::importMmRecords() and then again in In2code\Migration\Port\Import::importFileReferenceRecords()

I'm quite sure that this does not break anything, but since I'm new to TYPO3 and also used this extension only for one project, please double check. In my case it works fine now.

All this happens for a config along these lines:

```php
// ...
'relations' => [
    'my_relation_table' => [
        [
        'table' => 'sys_file_reference',
        'uid_local' => 'sys_file',
        'uid_foreign' => 'my_relation_table',
        'additional' => [
            'tablenames' => 'my_relation_table',
            'fieldname' => 'my_relation_table_field'
        ]
    ],
    // ...
],
// ...
```
